### PR TITLE
Requester Email Added to New Import

### DIFF
--- a/RangeImportSupportTool.API/Callers/RangeImportApiCaller.cs
+++ b/RangeImportSupportTool.API/Callers/RangeImportApiCaller.cs
@@ -43,7 +43,7 @@ namespace RangeImportSupportTool.APIService.Callers
                     RangeImport rangeImportModel = new()
                     {
                         Id = ticket.Id,
-                        TargetUsage = targetUsageList, 
+                        TargetUsage = targetUsageList,
                         Action = requestedItemsJsonParse.SelectToken("requested_items.[0].custom_fields.which_tasks_do_you_require.[0]").Value<string>(),
                         RetailerName = requestedItemsJsonParse.SelectToken("requested_items.[0].custom_fields.retailer_name").Value<string>(),
                         BatchName = requestedItemsJsonParse.SelectToken("requested_items.[0].custom_fields.retailer_range_name").Value<string>(),
@@ -52,7 +52,8 @@ namespace RangeImportSupportTool.APIService.Callers
                         TargetMarket = requestedItemsJsonParse.SelectToken("requested_items.[0].custom_fields.which_target_market_is_this_for").Value<string>(),
                         UsePreferredSupplier = requestedItemsJsonParse.SelectToken("requested_items.[0].custom_fields.use_preferred_supplier_matching").Value<string>(),
                         PurposeId = requestedItemsJsonParse.SelectToken("requested_items.[0].custom_fields.purpose_id_if_required").Value<string>(),
-                        NumberOfReplies = conversationInfoJsonParse.SelectToken("meta.count").Value<int>()
+                        NumberOfReplies = conversationInfoJsonParse.SelectToken("meta.count").Value<int>(),
+                        RequesterEmail = conversationInfoJsonParse.SelectToken("conversations.[0].to_emails.[0]").Value<string>()
                     };
 
                     // Check if the range import is a new batch or not

--- a/RangeImportSupportTool.WPF/Views/HomeView.xaml
+++ b/RangeImportSupportTool.WPF/Views/HomeView.xaml
@@ -115,9 +115,8 @@
                     <GridViewColumn Header="Use Pref. Supplier?" Width="110" DisplayMemberBinding="{Binding UsePreferredSupplier}" />
                     <GridViewColumn Header="Target Market" Width="100" DisplayMemberBinding="{Binding TargetMarket}" />
                     <GridViewColumn Header="PurposeId" Width="60" DisplayMemberBinding="{Binding PurposeId}" />
-                    <GridViewColumn Header="New report?" Width="90" DisplayMemberBinding="{Binding IsNewReport}" />
                     <GridViewColumn Header="TicketID" Width="50" DisplayMemberBinding="{Binding Id}" />
-                    <GridViewColumn Header="No. Replies" Width="50" DisplayMemberBinding="{Binding NumberOfReplies}" />
+                    <GridViewColumn Header="Email" Width="100" DisplayMemberBinding="{Binding RequesterEmail}" />
                     <GridViewColumn Header="BatchID" Width="100">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>


### PR DESCRIPTION
- RangeImport model has a new property added "RequesterEmail"
- RangeImportApiCaller now populates the RequesterEmail property
- HomeView has been amended to show the requester email, and to remove a few columns from the new import section

Possible issues
- The RangeImportApiCaller takes the email address from the reply_to when the ticket is assigned. This could cause issues if the ticket is not assigned but the tool is used, however this is highly unlikely to happen as tickets are assigned almost immediately to the correct user.